### PR TITLE
feat: Release V1.2.8 with PP-OCRv6 multilingual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@
 
 
 # CnSTD
+## Update 2026.07.04：发布 V1.2.8
+
+主要变更：
+
+* 基于 RapidOCR 支持 PP-OCRv6 多语种文本检测模型
+  * 新增支持 PP-OCRv6 检测模型：`multi_PP-OCRv6_det_tiny`、`multi_PP-OCRv6_det_small` 和 `multi_PP-OCRv6_det_medium`
+  * CLI 新增 `--lang-type`，可为 RapidOCR v6 检测模型指定语言类型
+
+
 ## Update 2025.06.25：发布 V1.2.6
 
 主要变更：
@@ -152,7 +161,7 @@ pip install cnstd -i https://mirrors.aliyun.com/pypi/simple
 
 CnSTD 从 **V1.2** 开始，可直接使用的模型包含两类：1）CnSTD 自己训练的模型，通常会包含 PyTorch 和 ONNX 版本；2）从其他ocr引擎搬运过来的训练好的外部模型，ONNX化后用于 CnSTD 中。
 
-直接使用的模型都放在 [**cnstd-cnocr-models**](https://huggingface.co/breezedeus/cnstd-cnocr-models) 项目中，可免费下载使用。
+直接使用的模型都放在 [**cnstd-cnocr-models**](https://huggingface.co/breezedeus/cnstd-cnocr-models) 或对应的 `breezedeus/cnstd-ppocr-*` HuggingFace 模型仓库中，可免费下载使用。
 
 ### 1. CnSTD 自己训练的模型
 
@@ -179,13 +188,18 @@ CnSTD 从 **V1.2** 开始，可直接使用的模型包含两类：1）CnSTD 自
 
 | `model_name`    | PyTorch 版本 | ONNX 版本 | 支持检测的语言    | 模型文件大小 |
 | --------------- | ---------- | ------- | ---------- | ------ |
-| ch_PP-OCRv5_det | X          | √       | 简体中问、英文、数字 | 4.6 M  |
-| ch_PP-OCRv5_det_server | X          | √       | 简体中问、英文、数字 | 84 M  |
-| ch_PP-OCRv4_det | X          | √       | 简体中问、英文、数字 | 4.5 M  |
-| ch_PP-OCRv4_det_server | X          | √       | 简体中问、英文、数字 | 108 M  |
-| ch_PP-OCRv3_det | X          | √       | 简体中问、英文、数字 | 2.3 M  |
+| multi_PP-OCRv6_det_tiny | X          | √       | 多语种（不含日文） | 1.7 M  |
+| multi_PP-OCRv6_det_small | X          | √       | 多语种 | 9.5 M  |
+| multi_PP-OCRv6_det_medium | X          | √       | 多语种 | 59 M  |
+| ch_PP-OCRv5_det | X          | √       | 简体中文、英文、数字 | 4.6 M  |
+| ch_PP-OCRv5_det_server | X          | √       | 简体中文、英文、数字 | 84 M  |
+| ch_PP-OCRv4_det | X          | √       | 简体中文、英文、数字 | 4.5 M  |
+| ch_PP-OCRv4_det_server | X          | √       | 简体中文、英文、数字 | 108 M  |
+| ch_PP-OCRv3_det | X          | √       | 简体中文、英文、数字 | 2.3 M  |
 | en_PP-OCRv3_det | X          | √       | **英文**、数字  | 2.3 M  |
-| ch_PP-OCRv2_det | X          | √       | 简体中问、英文、数字 | 2.2 M  |
+| ch_PP-OCRv2_det | X          | √       | 简体中文、英文、数字 | 2.2 M  |
+
+PP-OCRv6 的 `multi_PP-OCRv6_det_small` 和 `multi_PP-OCRv6_det_medium` 支持的 `lang_type` 包括：`ch`, `chinese_cht`, `en`, `japan`, `af`, `az`, `bs`, `ca`, `cs`, `cy`, `da`, `de`, `es`, `et`, `eu`, `fi`, `fr`, `ga`, `gl`, `hr`, `hu`, `id`, `is`, `it`, `ku`, `la`, `lb`, `lt`, `lv`, `mi`, `ms`, `mt`, `nl`, `no`, `oc`, `pl`, `pt`, `qu`, `rm`, `ro`, `rs_latin`, `sk`, `sl`, `sq`, `sv`, `sw`, `tl`, `tr`, `uz`, `vi`, `french`, `german`；`multi_PP-OCRv6_det_tiny` 不支持 `japan`。`multi` 是模型族名称，不是可传入的 `lang_type`。
 
 
 更多模型可参考 [PaddleOCR/models_list.md](https://github.com/PaddlePaddle/PaddleOCR/blob/release%2F2.5/doc/doc_ch/models_list.md) 。如有其他外语（如日、韩等）检测需求，可在 **知识星球** [**CnOCR/CnSTD私享群**](https://t.zsxq.com/FEYZRJQ) 中向作者提出建议。
@@ -208,7 +222,7 @@ class CnStd(object):
 
     def __init__(
         self,
-        model_name: str = 'ch_PP-OCRv5_det',
+        model_name: str = 'multi_PP-OCRv6_det_small',
         *,
         auto_rotate_whole_image: bool = False,
         rotated_bbox: bool = True,
@@ -224,7 +238,7 @@ class CnStd(object):
 
 其中的几个参数含义如下：
 
-* `model_name`:  模型名称，即前面模型表格第一列中的值。默认为 **ch_PP-OCRv5_det** 。
+* `model_name`:  模型名称，即前面模型表格第一列中的值。默认为 **multi_PP-OCRv6_det_small** 。
 
 * `auto_rotate_whole_image`:  是否自动对整张图片进行旋转调整。默认为`False`。
 
@@ -238,7 +252,7 @@ class CnStd(object):
 
 * `root`: 模型文件所在的根目录。
   
-  * Linux/Mac下默认值为 `~/.cnstd`，表示模型文件所处文件夹类似 `~/.cnstd/1.2/db_shufflenet_v2_small`。
+  * Linux/Mac下默认值为 `~/.cnstd`，表示模型文件所处文件夹类似 `~/.cnstd/1.2/ppocr/multi_PP-OCRv6_det_small`。
   * Windows下默认值为 `C:\Users\<username>\AppData\Roaming\cnstd`。
 
 * `use_angle_clf` (bool): 对于检测出的文本框，是否使用角度分类模型进行调整（检测出的文本框可能会存在倒转180度的情况）。默认为 `False`
@@ -497,11 +511,13 @@ Usage: cnstd predict [OPTIONS]
   预测单个文件，或者指定目录下的所有图片
 
 Options:
-  -m, --model-name [ch_PP-OCRv2_det|ch_PP-OCRv3_det|ch_PP-OCRv4_det|ch_PP-OCRv4_det_server|ch_PP-OCRv5_det|ch_PP-OCRv5_det_server|db_mobilenet_v3|db_mobilenet_v3_small|db_resnet18|db_resnet34|db_shufflenet_v2|db_shufflenet_v2_small|en_PP-OCRv3_det]
-                                  模型名称。默认值为 db_shufflenet_v2_small
+  -m, --model-name [ch_PP-OCRv2_det|ch_PP-OCRv3_det|ch_PP-OCRv4_det|ch_PP-OCRv4_det_server|ch_PP-OCRv5_det|ch_PP-OCRv5_det_server|db_mobilenet_v3|db_mobilenet_v3_small|db_resnet18|db_resnet34|db_shufflenet_v2|db_shufflenet_v2_small|en_PP-OCRv3_det|multi_PP-OCRv6_det_medium|multi_PP-OCRv6_det_small|multi_PP-OCRv6_det_tiny]
+                                  模型名称。默认值为 multi_PP-OCRv6_det_small
   -b, --model-backend [pytorch|onnx]
                                   模型类型。默认值为 `onnx`
   -p, --pretrained-model-fp TEXT  使用训练好的模型。默认为 `None`，表示使用系统自带的预训练模型
+  --lang-type TEXT                RapidOCR检测模型的语言类型；PP-OCRv6支持如
+                                  ch、en、japan、french、german 等。默认值为 `None`
   -r, --rotated-bbox              是否检测带角度（非水平和垂直）的文本框
   --resized-shape TEXT            格式："height,width";
                                   预测时把图片resize到此大小再进行预测。两个值都需要是32的倍数。默认为
@@ -520,6 +536,12 @@ Options:
 
 ```bash
 cnstd predict -i examples/taobao.jpg -o outputs
+```
+
+PP-OCRv6 多语种检测模型可通过 `--lang-type` 指定语言类型：
+
+```bash
+cnstd predict -m multi_PP-OCRv6_det_small --lang-type en -i examples/taobao.jpg -o outputs
 ```
 
 具体使用也可参考文件 [Makefile](./Makefile) 。

--- a/README_en.md
+++ b/README_en.md
@@ -22,6 +22,15 @@
 
 # CnSTD
 
+## Update 2026.07.04: Release V1.2.8
+
+Main changes:
+
+* Added RapidOCR-based PP-OCRv6 multilingual text detection models
+  * New PP-OCRv6 detection models: `multi_PP-OCRv6_det_tiny`, `multi_PP-OCRv6_det_small`, and `multi_PP-OCRv6_det_medium`
+  * Added the CLI option `--lang-type` for setting the language type used by RapidOCR v6 detection models
+
+
 ## Update 2025.06.25: Release V1.2.6
 
 Major Changes:
@@ -144,7 +153,7 @@ pip install cnstd -i https://mirrors.aliyun.com/pypi/simple
 
 Starting from **V1.2**, CnSTD includes two types of models: 1) models trained by CnSTD, usually available in PyTorch and ONNX versions; 2) pre-trained models from other OCR engines, converted to ONNX for use in CnSTD.
 
-Downloadable models are available in the [**cnstd-cnocr-models**](https://huggingface.co/breezedeus/cnstd-cnocr-models) project.
+Downloadable models are available in the [**cnstd-cnocr-models**](https://huggingface.co/breezedeus/cnstd-cnocr-models) project or the corresponding `breezedeus/cnstd-ppocr-*` HuggingFace model repositories.
 
 ### 1. CnSTD Trained Models
 
@@ -171,12 +180,17 @@ The following models are ONNX versions from [**PaddleOCR**](https://github.com/P
 
 | `model_name`    | PyTorch Version | ONNX Version | Supported Languages         | Model File Size |
 |-----------------|-----------------|--------------|----------------------------|-----------------|
+| multi_PP-OCRv6_det_tiny | X        | √            | Multilingual, except Japanese | 1.7 M         |
+| multi_PP-OCRv6_det_small | X       | √            | Multilingual               | 9.5 M           |
+| multi_PP-OCRv6_det_medium | X      | √            | Multilingual               | 59 M            |
 | ch_PP-OCRv5_det | X               | √            | Chinese, English, Numbers  | 4.6 M           |
 | ch_PP-OCRv5_det_server | X        | √            | Chinese, English, Numbers  | 84 M            |
 | ch_PP-OCRv4_det | X               | √            | Chinese, English, Numbers  | 4.5 M           |
 | ch_PP-OCRv4_det_server | X        | √            | Chinese, English, Numbers  | 108 M           |
 | ch_PP-OCRv3_det | X               | √            | Chinese, English, Numbers  | 2.2 M           |
 | en_PP-OCRv3_det | X               | √            | **English**, Numbers       | 2.3 M           |
+
+For PP-OCRv6, `multi_PP-OCRv6_det_small` and `multi_PP-OCRv6_det_medium` support these `lang_type` values: `ch`, `chinese_cht`, `en`, `japan`, `af`, `az`, `bs`, `ca`, `cs`, `cy`, `da`, `de`, `es`, `et`, `eu`, `fi`, `fr`, `ga`, `gl`, `hr`, `hu`, `id`, `is`, `it`, `ku`, `la`, `lb`, `lt`, `lv`, `mi`, `ms`, `mt`, `nl`, `no`, `oc`, `pl`, `pt`, `qu`, `rm`, `ro`, `rs_latin`, `sk`, `sl`, `sq`, `sv`, `sw`, `tl`, `tr`, `uz`, `vi`, `french`, and `german`. `multi_PP-OCRv6_det_tiny` does not support `japan`. `multi` is the model family name, not a valid `lang_type`.
 
 For more models, refer to [PaddleOCR/models_list
 
@@ -200,7 +214,7 @@ class CnStd(object):
 
     def __init__(
         self,
-        model_name: str = 'ch_PP-OCRv5_det',
+        model_name: str = 'multi_PP-OCRv6_det_small',
         *,
         auto_rotate_whole_image: bool = False,
         rotated_bbox: bool = True,
@@ -216,7 +230,7 @@ class CnStd(object):
 
 Key parameters:
 
-* `model_name`: Model name, corresponding to the first column in the model table. Default is **ch_PP-OCRv5_det**.
+* `model_name`: Model name, corresponding to the first column in the model table. Default is **multi_PP-OCRv6_det_small**.
 * `auto_rotate_whole_image`: Automatically adjust the rotation of the entire image. Default is `False`.
 * `rotated_bbox`: Support detection of angled text boxes; Default is `True`. If `False`, only horizontal or vertical text is detected.
 * `context`: Resource for prediction, can be `cpu`, `gpu`, or `cuda:0`.
@@ -441,11 +455,12 @@ Usage: cnstd predict [OPTIONS]
   Predict text in a single file or all images in a directory.
 
 Options:
-  -m, --model-name [ch_PP-OCRv2_det|ch_PP-OCRv3_det|ch_PP-OCRv4_det|ch_PP-OCRv4_det_server|ch_PP-OCRv5_det|ch_PP-OCRv5_det_server|db_mobilenet_v3|db_mobilenet_v3_small|db_resnet18|db_resnet34|db_shufflenet_v2|db_shufflenet_v2_small|en_PP-OCRv3_det]
-                                  Model name. Default: db_shufflenet_v2_small.
+  -m, --model-name [ch_PP-OCRv2_det|ch_PP-OCRv3_det|ch_PP-OCRv4_det|ch_PP-OCRv4_det_server|ch_PP-OCRv5_det|ch_PP-OCRv5_det_server|db_mobilenet_v3|db_mobilenet_v3_small|db_resnet18|db_resnet34|db_shufflenet_v2|db_shufflenet_v2_small|en_PP-OCRv3_det|multi_PP-OCRv6_det_medium|multi_PP-OCRv6_det_small|multi_PP-OCRv6_det_tiny]
+                                  Model name. Default: multi_PP-OCRv6_det_small.
   -b, --model-backend [pytorch|onnx]
                                   Model type. Default: `onnx`.
   -p, --pretrained-model-fp TEXT  Pre-trained model. Default: `None`.
+  --lang-type TEXT                RapidOCR detection model language type. PP-OCRv6 supports values such as ch, en, japan, french, and german. Default: `None`.
   -r, --rotated-bbox              Detect angled text boxes. Default: `True`.
   --resized-shape TEXT            Format: "height,width". Resize image to this size for prediction. Values should be multiples of 32. Default: `768,768`.
   --box-score-thresh FLOAT        Filter out text boxes with a score lower than this value. Default: `0.3`.
@@ -460,6 +475,12 @@ Example to detect text in `examples/taobao.jpg` and save results to `outputs`:
 
 ```bash
 cnstd predict -i examples/taobao.jpg -o outputs
+```
+
+For PP-OCRv6 multilingual detection models, use `--lang-type` to set the language type:
+
+```bash
+cnstd predict -m multi_PP-OCRv6_det_small --lang-type en -i examples/taobao.jpg -o outputs
 ```
 
 See the [Makefile](./Makefile) for more usage.

--- a/cnstd/__init__.py
+++ b/cnstd/__init__.py
@@ -17,6 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+
 from .detector import Detector
 from .ppocr import PPDetector
 from .yolov7.layout_analyzer import LayoutAnalyzer, save_layout_img

--- a/cnstd/__version__.py
+++ b/cnstd/__version__.py
@@ -17,4 +17,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-__version__ = '1.2.7.3'
+__version__ = '1.2.8'

--- a/cnstd/cli.py
+++ b/cnstd/cli.py
@@ -49,6 +49,7 @@ _CONTEXT_SETTINGS = {"help_option_names": ['-h', '--help']}
 
 logger = set_logger(log_level='INFO')
 DEFAULT_MODEL_NAME = 'db_shufflenet_v2_small'
+DEFAULT_DET_MODEL_NAME = 'multi_PP-OCRv6_det_small'
 
 
 @click.group(context_settings=_CONTEXT_SETTINGS)
@@ -180,8 +181,8 @@ MODELS = sorted(MODELS)
     '-m',
     '--model-name',
     type=click.Choice(MODELS),
-    default=DEFAULT_MODEL_NAME,
-    help='模型名称。默认值为 %s' % DEFAULT_MODEL_NAME,
+    default=DEFAULT_DET_MODEL_NAME,
+    help='模型名称。默认值为 %s' % DEFAULT_DET_MODEL_NAME,
 )
 @click.option(
     '-b',
@@ -196,6 +197,12 @@ MODELS = sorted(MODELS)
     type=str,
     default=None,
     help='使用训练好的模型。默认为 `None`，表示使用系统自带的预训练模型',
+)
+@click.option(
+    '--lang-type',
+    type=str,
+    default=None,
+    help='RapidOCR检测模型的语言类型；PP-OCRv6支持如 ch、en、japan、french、german 等。默认值为 `None`',
 )
 @click.option("-r", "--rotated-bbox", is_flag=True, help="是否检测带角度（非水平和垂直）的文本框")
 @click.option(
@@ -227,6 +234,7 @@ def predict(
     model_name,
     model_backend,
     pretrained_model_fp,
+    lang_type,
     rotated_bbox,
     resized_shape,
     box_score_thresh,
@@ -242,6 +250,7 @@ def predict(
         model_fp=pretrained_model_fp,
         rotated_bbox=rotated_bbox,
         context=context,
+        lang_type=lang_type,
     )
 
     resized_shape = list(map(int, resized_shape.split(',')))  # [H, W]
@@ -303,7 +312,7 @@ def predict(
             % (len(cropped_img_list), time_cost, time_cost / len(cropped_img_list))
         )
         logger.info('ocr result: \n%s' % pformat(ocr_out))
-    except ModuleNotFoundError as e:
+    except Exception as e:
         logger.warning(e)
 
 

--- a/cnstd/cn_std.py
+++ b/cnstd/cn_std.py
@@ -43,7 +43,7 @@ class CnStd(object):
 
     def __init__(
         self,
-        model_name: str = 'ch_PP-OCRv5_det',
+        model_name: str = 'multi_PP-OCRv6_det_small',
         *,
         auto_rotate_whole_image: bool = False,
         rotated_bbox: bool = True,
@@ -57,7 +57,7 @@ class CnStd(object):
     ):
         """
         Args:
-            model_name: 模型名称。默认为 'ch_PP-OCRv5_det'
+            model_name: 模型名称。默认为 'multi_PP-OCRv6_det_small'
             auto_rotate_whole_image: 是否自动对整张图片进行旋转调整。默认为False
             rotated_bbox: 是否支持检测带角度的文本框；默认为 True，表示支持；取值为 False 时，只检测水平或垂直的文本
             context: 'cpu', or 'gpu'。表明预测时是使用CPU还是GPU。默认为CPU
@@ -65,7 +65,7 @@ class CnStd(object):
             model_backend (str): 'pytorch', or 'onnx'。表明预测时是使用 PyTorch 版本模型，还是使用 ONNX 版本模型。
                 同样的模型，ONNX 版本的预测速度一般是 PyTorch 版本的2倍左右。默认为 'onnx'。
             root: 模型文件所在的根目录。
-                Linux/Mac下默认值为 `~/.cnstd`，表示模型文件所处文件夹类似 `~/.cnstd/1.2/db_resnet18`
+                Linux/Mac下默认值为 `~/.cnstd`，表示模型文件所处文件夹类似 `~/.cnstd/1.2/ppocr/multi_PP-OCRv6_det_small`
                 Windows下默认值为 `C:/Users/<username>/AppData/Roaming/cnstd`。
             use_angle_clf (bool): 对于检测出的文本框，是否使用角度分类模型进行调整（检测出的文本框可能会存在倒转180度的情况）。
                 默认为 `False`
@@ -105,6 +105,18 @@ class CnStd(object):
             model_backend=model_backend,
             root=root,
             **kwargs,
+        )
+        det_effective_lang_type = getattr(self.det_model, '_lang_type', None)
+        det_effective_lang_type = getattr(
+            det_effective_lang_type, 'value', det_effective_lang_type
+        )
+        logger.info(
+            'use det model: name=%s, backend=%s, lang_type=%s, fp=%s',
+            model_name,
+            model_backend,
+            det_effective_lang_type,
+            getattr(self.det_model, '_model_fp', model_fp),
+            extra={'log_color': 'green'},
         )
 
         self.use_angle_clf = use_angle_clf

--- a/cnstd/ppocr/consts.py
+++ b/cnstd/ppocr/consts.py
@@ -46,6 +46,18 @@ MODEL_LABELS_FILE_DICT = {
         'detector': 'RapidDetector',
         'repo': 'breezedeus/cnstd-ppocr-ch_PP-OCRv5_det_server',
     },
+    ('multi_PP-OCRv6_det_tiny', 'onnx'): {
+        'detector': 'RapidDetector',
+        'repo': 'breezedeus/cnstd-ppocr-multi_PP-OCRv6_det_tiny',
+    },
+    ('multi_PP-OCRv6_det_small', 'onnx'): {
+        'detector': 'RapidDetector',
+        'repo': 'breezedeus/cnstd-ppocr-multi_PP-OCRv6_det_small',
+    },
+    ('multi_PP-OCRv6_det_medium', 'onnx'): {
+        'detector': 'RapidDetector',
+        'repo': 'breezedeus/cnstd-ppocr-multi_PP-OCRv6_det_medium',
+    },
 }
 
 PP_SPACE = 'ppocr'

--- a/cnstd/ppocr/rapid_detector.py
+++ b/cnstd/ppocr/rapid_detector.py
@@ -30,10 +30,11 @@ import cv2
 # from rapidocr_onnxruntime import RapidOCR
 from rapidocr import EngineType, LangDet, ModelType, OCRVersion
 from rapidocr.utils.typings import TaskType
+from rapidocr.utils.model_resolver import resolve_model_key
 from rapidocr.ch_ppocr_det import TextDetector
 
 from ..consts import AVAILABLE_MODELS, MODEL_VERSION
-from ..utils import read_img, data_dir, prepare_model_files
+from ..utils import read_img, data_dir, prepare_model_files, set_rapidocr_logger_level
 from .utility import get_rotate_crop_image
 from .consts import PP_SPACE
 
@@ -48,6 +49,7 @@ class Config(dict):
         "task_type": TaskType.DET,
         "model_path": None,
         "model_dir": None,
+        "model_root_dir": None,
         "limit_side_len": 736,
         "limit_type": "min",
         "std": [0.5, 0.5, 0.5],
@@ -109,7 +111,7 @@ class RapidDetector(object):
 
     def __init__(
         self,
-        model_name: str = 'ch_PP-OCRv5_det',
+        model_name: str = 'multi_PP-OCRv6_det_small',
         *,
         model_fp: Optional[str] = None,
         root: Union[str, Path] = data_dir(),
@@ -140,8 +142,16 @@ class RapidDetector(object):
             score_mode: 得分模式，可选值为 'fast' 或 'slow'，默认为 'fast'
             kwargs: 其他参数
         """
+        set_rapidocr_logger_level()
         self._model_name = model_name
         self._model_backend = 'onnx'
+        lang_type = kwargs.pop("lang_type", None)
+        model_type = self._get_model_type(model_name)
+        ocr_version = self._get_ocr_version(model_name)
+        lang_type = self._get_lang_type(model_name, model_type, lang_type)
+        self._model_type = model_type
+        self._ocr_version = ocr_version
+        self._lang_type = lang_type
         self._assert_and_prepare_model_files(model_fp, root)
         use_gpu = context.lower() not in ('cpu', 'mps')
 
@@ -153,7 +163,10 @@ class RapidDetector(object):
 
         model_root_dir = kwargs.pop("model_root_dir", None)
         if model_root_dir is None:
-            model_root_dir = getattr(self, "_model_dir", os.path.dirname(self._model_fp))
+            if hasattr(self, "_model_dir"):
+                model_root_dir = self._model_dir
+            else:
+                model_root_dir = os.path.dirname(self._model_fp)
 
         config.update({
             "limit_side_len": limit_side_len,
@@ -169,23 +182,109 @@ class RapidDetector(object):
         })
         config.update(kwargs)
         # 从 model_name 中获取 model_type 和 ocr_version
-        config["model_type"] = ModelType.SERVER if "server" in model_name else ModelType.MOBILE
-        config["ocr_version"] = OCRVersion.PPOCRV5 if "v5" in model_name else OCRVersion.PPOCRV4
+        config["model_type"] = model_type
+        config["ocr_version"] = ocr_version
+        config["lang_type"] = lang_type
 
         config = Config(config)
         self._detector = TextDetector(config)
+
+    @staticmethod
+    def _get_ocr_version(model_name: str):
+        if "v6" in model_name:
+            if not hasattr(OCRVersion, "PPOCRV6"):
+                raise RuntimeError(
+                    "PP-OCRv6 models require rapidocr>=3.9.0. "
+                    "Please upgrade rapidocr to use this model."
+                )
+            return OCRVersion.PPOCRV6
+        if "v5" in model_name:
+            return OCRVersion.PPOCRV5
+        return OCRVersion.PPOCRV4
+
+    @staticmethod
+    def _get_model_type(model_name: str):
+        if "server" in model_name:
+            return ModelType.SERVER
+        for model_type in ("tiny", "small", "medium"):
+            if model_type in model_name:
+                if not hasattr(ModelType, model_type.upper()):
+                    raise RuntimeError(
+                        "PP-OCRv6 models require rapidocr>=3.9.0. "
+                        "Please upgrade rapidocr to use this model."
+                    )
+                return getattr(ModelType, model_type.upper())
+        if "v6" in model_name:
+            if not hasattr(ModelType, "SMALL"):
+                raise RuntimeError(
+                    "PP-OCRv6 models require rapidocr>=3.9.0. "
+                    "Please upgrade rapidocr to use this model."
+                )
+            return ModelType.SMALL
+        return ModelType.MOBILE
+
+    @classmethod
+    def _get_model_file_name(cls, model_name: str):
+        if "v6" in model_name:
+            model_type = cls._get_model_type(model_name).value
+            return f"PP-OCRv6_det_{model_type}.onnx"
+        return '%s_infer.onnx' % model_name
+
+    @staticmethod
+    def _get_lang_type(model_name: str, model_type: ModelType, lang_type=None):
+        # RapidOCR's PP-OCRv6 model files are named "multi_*", but its
+        # resolver expects a concrete language and maps it to the multi model.
+        if lang_type is None:
+            return LangDet.CH
+
+        normalized = lang_type.value if hasattr(lang_type, "value") else str(lang_type)
+        normalized = normalized.strip().lower()
+        if "v6" in model_name and normalized == "multi":
+            raise ValueError(
+                "PP-OCRv6 requires a concrete lang_type such as 'ch' or 'en'; "
+                "'multi' is the model family name, not a valid v6 lang_type."
+            )
+        if "v6" in model_name:
+            resolve_model_key(
+                TaskType.DET, OCRVersion.PPOCRV6, lang_type, model_type
+            )
+        return lang_type
 
     def _assert_and_prepare_model_files(self, model_fp, root):
         if model_fp is not None and not os.path.isfile(model_fp):
             raise FileNotFoundError('can not find model file %s' % model_fp)
 
+        root = os.path.join(root, MODEL_VERSION)
+        self._model_dir = os.path.join(root, PP_SPACE, self._model_name)
+
         if model_fp is not None:
             self._model_fp = model_fp
             return
 
-        root = os.path.join(root, MODEL_VERSION)
-        self._model_dir = os.path.join(root, PP_SPACE, self._model_name)
-        model_fp = os.path.join(self._model_dir, '%s_infer.onnx' % self._model_name)
+        if "v6" in self._model_name:
+            if (self._model_name, self._model_backend) not in AVAILABLE_MODELS:
+                raise NotImplementedError(
+                    '%s is not a downloadable model'
+                    % ((self._model_name, self._model_backend),)
+                )
+            remote_repo = AVAILABLE_MODELS.get_value(
+                self._model_name, self._model_backend, 'repo'
+            )
+            if remote_repo is None:
+                raise RuntimeError(
+                    'no remote repo is configured for model %s'
+                    % ((self._model_name, self._model_backend),)
+                )
+            model_fp = os.path.join(
+                self._model_dir, self._get_model_file_name(self._model_name)
+            )
+            self._model_fp = str(prepare_model_files(model_fp, remote_repo))
+            logger.info('use model: %s' % self._model_fp)
+            return
+
+        model_fp = os.path.join(
+            self._model_dir, self._get_model_file_name(self._model_name)
+        )
         if not os.path.isfile(model_fp):
             logger.warning('can not find model file %s' % model_fp)
             if (self._model_name, self._model_backend) not in AVAILABLE_MODELS:

--- a/cnstd/utils/utils.py
+++ b/cnstd/utils/utils.py
@@ -39,9 +39,49 @@ from huggingface_hub import hf_hub_download
 
 from ..consts import MODEL_VERSION, MODEL_CONFIGS, HF_ENDPOINT_LIST
 
-fmt = '[%(levelname)s %(asctime)s %(funcName)s:%(lineno)d] %(' 'message)s '
+LOG_FMT = '[%(levelname)s] %(asctime)s [%(package_name)s] %(filename)s:%(lineno)d: %(message)s'
+GREEN = '\033[32m'
+RESET = '\033[0m'
+
+
+def _package_label(logger_name):
+    if logger_name.startswith('cnstd'):
+        return 'CnSTD'
+    if logger_name.startswith('RapidOCR'):
+        return 'RapidOCR'
+    return logger_name.split('.', maxsplit=1)[0]
+
+
+class PackageFormatter(logging.Formatter):
+    def format(self, record):
+        record.package_name = _package_label(record.name)
+        return super().format(record)
+
+
+class ColoredFormatter(PackageFormatter):
+    def format(self, record):
+        msg = super().format(record)
+        if getattr(record, 'log_color', None) == 'green':
+            return GREEN + msg + RESET
+        return msg
 
 logger = logging.getLogger(__name__)
+
+
+def set_rapidocr_logger_level(log_level=logging.WARNING):
+    logging.getLogger('RapidOCR').setLevel(log_level)
+
+
+def _console_handler():
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(ColoredFormatter(LOG_FMT))
+    return console_handler
+
+
+def get_logger(name=__name__, log_level=logging.INFO):
+    logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+    return logger
 
 
 def set_logger(log_file=None, log_level=logging.INFO, log_file_level=logging.NOTSET):
@@ -51,14 +91,17 @@ def set_logger(log_file=None, log_level=logging.INFO, log_file_level=logging.NOT
         >>> logger.info("abc'")
     """
     global logger
-    log_format = logging.Formatter(fmt)
-    logging.basicConfig(format=fmt)
+    log_format = PackageFormatter(LOG_FMT)
     logging.captureWarnings(True)
-    logger = logging.getLogger(__name__)
-    logger.setLevel(log_level)
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(log_format)
-    logger.handlers = [console_handler]
+    set_rapidocr_logger_level()
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.handlers = [_console_handler()]
+    package_logger = logging.getLogger('cnstd')
+    package_logger.setLevel(logging.NOTSET)
+    package_logger.propagate = True
+
     if log_file and log_file != '':
         if not Path(log_file).parent.exists():
             os.makedirs(Path(log_file).parent)
@@ -67,7 +110,9 @@ def set_logger(log_file=None, log_level=logging.INFO, log_file_level=logging.NOT
         file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(log_file_level)
         file_handler.setFormatter(log_format)
-        logger.addHandler(file_handler)
+        root_logger.addHandler(file_handler)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(log_level)
     return logger
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -22,4 +22,4 @@ onnx
 onnxruntime
 huggingface_hub
 ultralytics
-rapidocr>=3.0,<3.8
+rapidocr>=3.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,7 +163,7 @@ pyyaml==6.0.2
     #   pytorch-lightning
     #   rapidocr
     #   ultralytics
-rapidocr==3.2.0
+rapidocr==3.9.1
     # via -r requirements.in
 requests==2.32.3
     # via

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ required = [
     "onnx",
     "huggingface_hub",
     "ultralytics",
-    "rapidocr>=3.0,<3.8",
+    "rapidocr>=3.9.1",
 ]
 
 extras_require = {
@@ -98,6 +98,7 @@ setup(
     ],
     install_requires=required,
     extras_require=extras_require,
+    python_requires='>=3.8',
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -107,7 +108,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: Implementation',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tests/test_rapidocr.py
+++ b/tests/test_rapidocr.py
@@ -162,6 +162,143 @@ def test_rapid_detector_respects_custom_model_root_dir():
     assert detector_calls[0].model_root_dir == custom_root_dir
 
 
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6") or not hasattr(ModelType, "SMALL"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_supports_ppocrv6_config():
+    detector_calls = []
+    prepare_calls = []
+
+    def fake_text_detector(config):
+        detector_calls.append(config)
+        return lambda img: None
+
+    def fake_prepare_model_files(model_fp, remote_repo):
+        prepare_calls.append((model_fp, remote_repo))
+        return model_fp
+
+    with patch(
+        "cnstd.ppocr.rapid_detector.TextDetector",
+        side_effect=fake_text_detector,
+    ), patch(
+        "cnstd.ppocr.rapid_detector.prepare_model_files",
+        side_effect=fake_prepare_model_files,
+    ):
+        detector = RapidDetector(model_name="multi_PP-OCRv6_det_small")
+
+    assert detector_calls
+    config = detector_calls[0]
+    assert config.ocr_version == OCRVersion.PPOCRV6
+    assert config.model_type == ModelType.SMALL
+    assert config.lang_type == LangDet.CH
+    assert config.model_path.endswith("PP-OCRv6_det_small.onnx")
+    assert config.model_root_dir == detector._model_dir
+    assert prepare_calls == [
+        (
+            os.path.join(detector._model_dir, "PP-OCRv6_det_small.onnx"),
+            "breezedeus/cnstd-ppocr-multi_PP-OCRv6_det_small",
+        )
+    ]
+
+
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6") or not hasattr(ModelType, "MEDIUM"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_supports_ppocrv6_medium_config():
+    detector_calls = []
+
+    def fake_text_detector(config):
+        detector_calls.append(config)
+        return lambda img: None
+
+    with patch(
+        "cnstd.ppocr.rapid_detector.TextDetector",
+        side_effect=fake_text_detector,
+    ), patch(
+        "cnstd.ppocr.rapid_detector.prepare_model_files",
+        side_effect=lambda model_fp, remote_repo: model_fp,
+    ):
+        RapidDetector(model_name="multi_PP-OCRv6_det_medium")
+
+    assert detector_calls[0].ocr_version == OCRVersion.PPOCRV6
+    assert detector_calls[0].model_type == ModelType.MEDIUM
+
+
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6") or not hasattr(ModelType, "SMALL"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_supports_ppocrv6_lang_override():
+    detector_calls = []
+
+    def fake_text_detector(config):
+        detector_calls.append(config)
+        return lambda img: None
+
+    with patch(
+        "cnstd.ppocr.rapid_detector.TextDetector",
+        side_effect=fake_text_detector,
+    ), patch(
+        "cnstd.ppocr.rapid_detector.prepare_model_files",
+        side_effect=lambda model_fp, remote_repo: model_fp,
+    ):
+        RapidDetector(model_name="multi_PP-OCRv6_det_small", lang_type=LangDet.EN)
+
+    assert detector_calls[0].lang_type == LangDet.EN
+
+
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6") or not hasattr(ModelType, "MEDIUM"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_supports_ppocrv6_string_lang_type():
+    detector_calls = []
+
+    def fake_text_detector(config):
+        detector_calls.append(config)
+        return lambda img: None
+
+    with patch(
+        "cnstd.ppocr.rapid_detector.TextDetector",
+        side_effect=fake_text_detector,
+    ), patch(
+        "cnstd.ppocr.rapid_detector.prepare_model_files",
+        side_effect=lambda model_fp, remote_repo: model_fp,
+    ):
+        RapidDetector(model_name="multi_PP-OCRv6_det_medium", lang_type="french")
+
+    assert detector_calls[0].lang_type == "french"
+
+
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_rejects_ppocrv6_multi_lang_type():
+    with pytest.raises(ValueError, match="concrete lang_type"):
+        RapidDetector(model_name="multi_PP-OCRv6_det_small", lang_type=LangDet.MULTI)
+
+
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6") or not hasattr(ModelType, "TINY"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_rejects_ppocrv6_tiny_japan_lang_type():
+    with pytest.raises(ValueError, match="Unsupported det.lang_type='japan'"):
+        RapidDetector(model_name="multi_PP-OCRv6_det_tiny", lang_type="japan")
+
+
+@pytest.mark.skipif(
+    not hasattr(OCRVersion, "PPOCRV6"),
+    reason="PP-OCRv6 requires rapidocr>=3.9.0",
+)
+def test_rapid_detector_rejects_unknown_ppocrv6_model():
+    with pytest.raises(NotImplementedError, match="not a downloadable model"):
+        RapidDetector(model_name="unknown_PP-OCRv6_det")
+
+
 def test_cnstd_passes_model_root_dir_to_rapid_detector():
     detector_calls = []
 


### PR DESCRIPTION
- Added support for PP-OCRv6 multilingual text detection models: `multi_PP-OCRv6_det_tiny`, `multi_PP-OCRv6_det_small`, and `multi_PP-OCRv6_det_medium`.
- Updated CLI to include `--lang-type` option for specifying language in RapidOCR v6 models.
- Changed default model name to `multi_PP-OCRv6_det_small` in CnStd class.
- Updated model repository links in documentation.
- Enhanced logging capabilities in the codebase.
- Updated requirements for rapidocr to version 3.9.1.
- Added tests for PP-OCRv6 model configurations and language type handling.